### PR TITLE
Fix bug in final return output of should_early_exit

### DIFF
--- a/dynasor/core/entropy.py
+++ b/dynasor/core/entropy.py
@@ -146,4 +146,4 @@ def should_early_exit(
                 # logger.debug(f"Early exit on: {answer_candidates = } ({is_certains = })")
                 return True
 
-    return True
+    return False


### PR DESCRIPTION
In the should_early_exit function, the final return should be False because the conditions are not met.

```
    # Number of answers should be greater than the threshold
    if len(answers) < continue_certain_bar:
        return False  # Early exit condition NOT met

    # The probe response text should not contain any uncertain words
    probe_response_text_lower = probe_response_text.lower()
    if any(word in probe_response_text_lower for word in uncertain_words):
        return False  # Early exit condition NOT met

    # The last answer window should be consistent
    answer_candidates = answers[-continue_certain_bar:]
    is_certains = is_certains[-continue_certain_bar:]
    if eqaul_group(answer_candidates):
        if count_not_empty(answer_candidates) == continue_certain_bar:
            if sum(is_certains) == continue_certain_bar:
                # logger.debug(f"Early exit on: {answer_candidates = } ({is_certains = })")
                return True  # Early exit condition MET!

    return True  # BUG: This should likely be False
```